### PR TITLE
Optimize rockcraft build

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -36,6 +36,7 @@ jobs:
     name: Combine Rocks and Push Multiarch Manifest
     uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@main
     needs: [build-and-push-arch-specifics]
+    if: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas != '[]' }}
     with:
-      rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.rock-metas }}
+      rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas }}
       dry-run: ${{ github.event_name != 'push' }}


### PR DESCRIPTION
Currently, for each change in the rockcraft repo, we publish the current state of rockcraft files and run tests on them even if files haven’t changed. We need to build only changed files but run tests on all rock images.

The PR updates pushed images after the build to only those modified rocks.

KU-1195