### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -6,4 +6,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
+        uses: canonical/has-signed-canonical-cla@046337b42822b7868ad62970988929c79f9c1d40 # v1

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab # main
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
@@ -19,13 +19,13 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
   run-tests:
-    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab # main
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:
       rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.rock-metas }}
   scan-images:
-    uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab # main
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:
@@ -34,7 +34,7 @@ jobs:
       trivy-image-config: ./trivy.yaml
   build-and-push-multiarch-manifest:
     name: Combine Rocks and Push Multiarch Manifest
-    uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab # main
     needs: [build-and-push-arch-specifics]
     if: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas != '[]' }}
     with:


### PR DESCRIPTION
Pin all GitHub Actions to their commit SHAs to improve supply chain security.

This prevents:
- Compromised tags from injecting malicious code
- Unexpected behavior from mutable references
- Supply chain attacks via action tag manipulation

Related: KU-5612